### PR TITLE
feat: do not send a body when the OAS does not require one

### DIFF
--- a/src/OpenApiDriver/openapi_executors.py
+++ b/src/OpenApiDriver/openapi_executors.py
@@ -2,6 +2,7 @@
 
 import json as _json
 from enum import Enum
+from logging import getLogger
 from pathlib import Path
 from random import choice
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -20,11 +21,13 @@ from requests.cookies import RequestsCookieJar as CookieJar
 from robot.api import Failure, SkipExecution
 from robot.api.deco import keyword, library
 from robot.libraries.BuiltIn import BuiltIn
-from robot.api import logger
 
 from OpenApiLibCore import OpenApiLibCore, RequestData, RequestValues, resolve_schema
 
 run_keyword = BuiltIn().run_keyword
+
+
+logger = getLogger(__name__)
 
 
 class ValidationLevel(str, Enum):
@@ -357,7 +360,7 @@ class OpenApiExecutors(OpenApiLibCore):  # pylint: disable=too-many-instance-att
                     )
                 # if the path supports GET, 404 is expected, if not 405 is expected
                 if get_response.status_code not in [404, 405]:
-                    logger.warn(
+                    logger.warning(
                         f"Unexpected response after deleting resource: Status_code "
                         f"{get_response.status_code} was received after trying to get {request_values.url} "
                         f"after sucessfully deleting it."
@@ -396,7 +399,7 @@ class OpenApiExecutors(OpenApiLibCore):  # pylint: disable=too-many-instance-att
 
         request_method = response.request.method
         if request_method is None:
-            logger.warn(
+            logger.warning(
                 f"Could not validate response for path {path}; no method found "
                 f"on the request property of the provided response."
             )
@@ -412,7 +415,7 @@ class OpenApiExecutors(OpenApiLibCore):  # pylint: disable=too-many-instance-att
         mime_type_from_response, _, _ = content_type_from_response.partition(";")
 
         if not response_spec.get("content"):
-            logger.warn(
+            logger.warning(
                 "The response cannot be validated: 'content' not specified in the OAS."
             )
             return None
@@ -510,7 +513,7 @@ class OpenApiExecutors(OpenApiLibCore):  # pylint: disable=too-many-instance-att
                 logger.error(error_message)
                 raise exception
             if self.response_validation == ValidationLevel.WARN:
-                logger.warn(error_message)
+                logger.warning(error_message)
             elif self.response_validation == ValidationLevel.INFO:
                 logger.info(error_message)
 
@@ -614,7 +617,7 @@ class OpenApiExecutors(OpenApiLibCore):  # pylint: disable=too-many-instance-att
 
         python_type = type_mapping.get(expected_type, None)
         if python_type is None:
-            logger.warn(
+            logger.warning(
                 f"Additonal properties were not validated: "
                 f"type '{expected_type}' is not supported."
             )
@@ -690,7 +693,7 @@ class OpenApiExecutors(OpenApiLibCore):  # pylint: disable=too-many-instance-att
                     )
 
         if response.request.body is None:
-            logger.warn(
+            logger.warning(
                 "Could not validate send response; the body of the request property "
                 "on the provided response was None."
             )

--- a/src/OpenApiDriver/openapi_executors.py
+++ b/src/OpenApiDriver/openapi_executors.py
@@ -55,7 +55,6 @@ class OpenApiExecutors(OpenApiLibCore):  # pylint: disable=too-many-instance-att
         default_id_property_name: str = "id",
         faker_locale: Optional[Union[str, List[str]]] = None,
         require_body_for_invalid_url: bool = False,
-        send_empty_body: bool = True,
         recursion_limit: int = 1,
         recursion_default: Any = {},
         username: str = "",
@@ -91,7 +90,6 @@ class OpenApiExecutors(OpenApiLibCore):  # pylint: disable=too-many-instance-att
         self.disable_server_validation = disable_server_validation
         self.require_body_for_invalid_url = require_body_for_invalid_url
         self.invalid_property_default_response = invalid_property_default_response
-        self.send_empty_body = send_empty_body
 
     @keyword
     def test_unauthorized(self, path: str, method: str) -> None:
@@ -174,8 +172,8 @@ class OpenApiExecutors(OpenApiLibCore):  # pylint: disable=too-many-instance-att
         request_data: RequestData = self.get_request_data(method=method, endpoint=path)
         params = request_data.params
         headers = request_data.headers
-        dict_data = request_data.dto.as_dict()
-        json_data = dict_data if dict_data or self.send_empty_body else None
+        if request_data.has_body:
+            json_data = request_data.dto.as_dict()
         # when patching, get the original data to check only patched data has changed
         if method == "PATCH":
             original_data = self.get_original_data(url=url)

--- a/src/OpenApiDriver/openapidriver.py
+++ b/src/OpenApiDriver/openapidriver.py
@@ -157,6 +157,7 @@ class OpenApiDriver(OpenApiExecutors, DataDriver):
         default_id_property_name: str = "id",
         faker_locale: Optional[Union[str, List[str]]] = None,
         require_body_for_invalid_url: bool = False,
+        send_empty_body: bool = True,
         recursion_limit: int = 1,
         recursion_default: Any = {},
         username: str = "",
@@ -254,6 +255,10 @@ class OpenApiDriver(OpenApiExecutors, DataDriver):
          processes the request body before checking if the requested resource exists, set
          this parameter to True.
 
+         === send_empty_body ===
+         If set to true, the request that would generate an empty body will not
+         send a body at all. Else it sends an empty body `{}`
+
          == Parsing parameters ==
 
          === recursion_limit ===
@@ -324,6 +329,7 @@ class OpenApiDriver(OpenApiExecutors, DataDriver):
             default_id_property_name=default_id_property_name,
             faker_locale=faker_locale,
             require_body_for_invalid_url=require_body_for_invalid_url,
+            send_empty_body=send_empty_body,
             recursion_limit=recursion_limit,
             recursion_default=recursion_default,
             username=username,

--- a/src/OpenApiDriver/openapidriver.py
+++ b/src/OpenApiDriver/openapidriver.py
@@ -157,7 +157,6 @@ class OpenApiDriver(OpenApiExecutors, DataDriver):
         default_id_property_name: str = "id",
         faker_locale: Optional[Union[str, List[str]]] = None,
         require_body_for_invalid_url: bool = False,
-        send_empty_body: bool = True,
         recursion_limit: int = 1,
         recursion_default: Any = {},
         username: str = "",
@@ -255,10 +254,6 @@ class OpenApiDriver(OpenApiExecutors, DataDriver):
          processes the request body before checking if the requested resource exists, set
          this parameter to True.
 
-         === send_empty_body ===
-         If set to true, the request that would generate an empty body will not
-         send a body at all. Else it sends an empty body `{}`
-
          == Parsing parameters ==
 
          === recursion_limit ===
@@ -329,7 +324,6 @@ class OpenApiDriver(OpenApiExecutors, DataDriver):
             default_id_property_name=default_id_property_name,
             faker_locale=faker_locale,
             require_body_for_invalid_url=require_body_for_invalid_url,
-            send_empty_body=send_empty_body,
             recursion_limit=recursion_limit,
             recursion_default=recursion_default,
             username=username,

--- a/src/OpenApiLibCore/openapi_libcore.py
+++ b/src/OpenApiLibCore/openapi_libcore.py
@@ -846,7 +846,7 @@ class OpenApiLibCore:  # pylint: disable=too-many-instance-attributes
                 parameters=parameters,
                 params=params,
                 headers=headers,
-                has_body=False
+                has_body=False,
             )
         content_schema = resolve_schema(self.get_content_schema(body_spec))
         dto_data = self.get_json_data_for_dto_class(

--- a/src/OpenApiLibCore/openapi_libcore.py
+++ b/src/OpenApiLibCore/openapi_libcore.py
@@ -201,6 +201,7 @@ class RequestData:
     parameters: List[Dict[str, Any]] = field(default_factory=list)
     params: Dict[str, Any] = field(default_factory=dict)
     headers: Dict[str, Any] = field(default_factory=dict)
+    has_body: bool = True
 
     def __post_init__(self) -> None:
         # prevent modification by reference
@@ -845,6 +846,7 @@ class OpenApiLibCore:  # pylint: disable=too-many-instance-attributes
                 parameters=parameters,
                 params=params,
                 headers=headers,
+                has_body=False
             )
         content_schema = resolve_schema(self.get_content_schema(body_spec))
         dto_data = self.get_json_data_for_dto_class(

--- a/tests/libcore/suites/test_get_request_data.robot
+++ b/tests/libcore/suites/test_get_request_data.robot
@@ -21,6 +21,7 @@ Test Get Request Data For Invalid Method On Endpoint
     Should Be Equal    ${request_data.parameters}    ${list}
     Should Be Equal    ${request_data.params}    ${dict}
     Should Be Equal    ${request_data.headers}    ${dict}
+    Should Not Be True    ${request_data.has_body}
 
 Test Get Request Data For Endpoint With RequestBody
     ${request_data}=    Get Request Data    endpoint=/employees    method=post
@@ -36,6 +37,7 @@ Test Get Request Data For Endpoint With RequestBody
     Should Be Equal    ${request_data.parameters}    ${list}
     Should Be Equal    ${request_data.params}    ${dict}
     Should Be Equal    ${request_data.headers}    ${dict}
+    Should Be True    ${request_data.has_body}
 
 Test Get Request Data For Endpoint Without RequestBody But With DtoClass
     ${request_data}=    Get Request Data    endpoint=/wagegroups/{wagegroup_id}    method=delete
@@ -45,6 +47,7 @@ Test Get Request Data For Endpoint Without RequestBody But With DtoClass
     Should Not Be Empty    ${request_data.parameters}
     Should Be Equal    ${request_data.params}    ${dict}
     Should Be Equal    ${request_data.headers}    ${dict}
+    Should Not Be True    ${request_data.has_body}
 
 # Test Get Request Data For Endpoint With RequestBody With Only Ignored Properties
 #    ${request_data}=    Get Request Data    endpoint=/wagegroups/{wagegroup_id}    method=delete
@@ -55,3 +58,4 @@ Test Get Request Data For Endpoint Without RequestBody But With DtoClass
 #    Should Not Be Empty    ${request_data.parameters}
 #    Should Be Equal    ${request_data.params}    ${dict}
 #    Should Be Equal    ${request_data.headers}    ${dict}
+#    Should Be True    ${request_data.has_body}


### PR DESCRIPTION
Fix the case where a body is not required: it used to send an empty body instead of no body at all, which in my case failed because the server was not expecting any body (it returned error 400 on a simple GET) (this can be controlled via lib arg `send_empty_body` which is True by default to stay backward compatible)

Also use the robot logger instead of python default logger to get better info from robot run