### PR TITLE
Refactored loading and caching of specs and validator

### DIFF
--- a/src/OpenApiLibCore/oas_cache.py
+++ b/src/OpenApiLibCore/oas_cache.py
@@ -1,5 +1,17 @@
-from typing import Dict
+from typing import Callable, Dict, Tuple
 
+from openapi_core import Spec
+from openapi_core.contrib.requests import (
+    RequestsOpenAPIRequest,
+    RequestsOpenAPIResponse,
+)
 from prance import ResolvingParser
 
-PARSER_CACHE: Dict[str, ResolvingParser] = {}
+PARSER_CACHE: Dict[
+    str,
+    Tuple[
+        ResolvingParser,
+        Spec,
+        Callable[[RequestsOpenAPIRequest, RequestsOpenAPIResponse], None],
+    ],
+] = {}


### PR DESCRIPTION
Ensure that all spec parsing happens before the first test case is executed. This prevents the first test case from taking a (very long) time in situations where parsing of the OAS / spec takes a long time.