### PR TITLE
Add support for PATCH http method

### DIFF
--- a/src/roboswag/core.py
+++ b/src/roboswag/core.py
@@ -69,6 +69,10 @@ class APIModel:
         # TODO handle files upload
         return self.send_request("POST", *args, **kwargs)
 
+    def patch(self, *args, **kwargs):
+        # TODO handle files upload
+        return self.send_request("PATCH", *args, **kwargs)
+
     def get(self, *args, **kwargs):
         return self.send_request("GET", *args, **kwargs)
 


### PR DESCRIPTION
The HTTP specification supports PATCH method. Some APIs make use of this method.

[PATCH method definition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH)